### PR TITLE
Add message argument to requireNonNull checks

### DIFF
--- a/src/main/java/io/reactivex/NbpObservable.java
+++ b/src/main/java/io/reactivex/NbpObservable.java
@@ -346,7 +346,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> NbpObservable<T> defer(Supplier<? extends NbpObservable<? extends T>> supplier) {
-        Objects.requireNonNull(supplier);
+        Objects.requireNonNull(supplier, "supplier is null");
         return create(new NbpOnSubscribeDefer<>(supplier));
     }
 
@@ -566,7 +566,7 @@ public class NbpObservable<T> {
     }
 
     public static <T> NbpObservable<T> just(T value) {
-        Objects.requireNonNull(value);
+        Objects.requireNonNull(value, "The value is null");
         return new NbpObservableScalarSource<>(value);
     }
 
@@ -880,7 +880,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T, R> NbpObservable<R> zip(NbpObservable<? extends NbpObservable<? extends T>> sources, Function<Object[], R> zipper) {
-        Objects.requireNonNull(zipper);
+        Objects.requireNonNull(zipper, "zipper is null");
         return sources.toList().flatMap(list -> {
             return zipIterable(zipper, false, bufferSize(), list);
         });
@@ -1002,7 +1002,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> ambWith(NbpObservable<? extends T> other) {
-        Objects.requireNonNull(other);
+        Objects.requireNonNull(other, "other is null");
         return amb(this, other);
     }
 
@@ -1160,7 +1160,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> cast(Class<U> clazz) {
-        Objects.requireNonNull(clazz);
+        Objects.requireNonNull(clazz, "clazz is null");
         return map(clazz::cast);
     }
 
@@ -1173,7 +1173,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> collectInto(U initialValue, BiConsumer<? super U, ? super T> collector) {
-        Objects.requireNonNull(initialValue);
+        Objects.requireNonNull(initialValue, "initialValue is null");
         return collect(() -> initialValue, collector);
     }
 
@@ -1197,7 +1197,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> concatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(mapper, "mapper is null");
         return concatMap(v -> fromIterable(mapper.apply(v)));
     }
 
@@ -1300,7 +1300,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<T> delaySubscription(Supplier<? extends NbpObservable<U>> delaySupplier) {
-        Objects.requireNonNull(delaySupplier);
+        Objects.requireNonNull(delaySupplier, "delaySupplier is null");
         return fromCallable(delaySupplier::get).flatMap(v -> v).take(1).cast(Object.class).defaultIfEmpty(OBJECT).flatMap(v -> this);
     }
 
@@ -1323,8 +1323,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K> NbpObservable<T> distinct(Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
-        Objects.requireNonNull(keySelector);
-        Objects.requireNonNull(collectionSupplier);
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return lift(NbpOperatorDistinct.withCollection(keySelector, collectionSupplier));
     }
 
@@ -1335,7 +1335,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K> NbpObservable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
-        Objects.requireNonNull(keySelector);
+        Objects.requireNonNull(keySelector, "keySelector is null");
         return lift(NbpOperatorDistinct.untilChanged(keySelector));
     }
 
@@ -1360,7 +1360,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> doOnEach(Consumer<? super Try<Optional<T>>> consumer) {
-        Objects.requireNonNull(consumer);
+        Objects.requireNonNull(consumer, "consumer is null");
         return doOnEach(
                 v -> consumer.accept(Try.ofValue(Optional.of(v))),
                 e -> consumer.accept(Try.ofError(e)),
@@ -1371,7 +1371,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> doOnEach(NbpSubscriber<? super T> observer) {
-        Objects.requireNonNull(observer);
+        Objects.requireNonNull(observer, "observer is null");
         return doOnEach(observer::onNext, observer::onError, observer::onComplete, () -> { });
     }
 
@@ -1382,8 +1382,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> doOnLifecycle(Consumer<? super Disposable> onSubscribe, Runnable onCancel) {
-        Objects.requireNonNull(onSubscribe);
-        Objects.requireNonNull(onCancel);
+        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        Objects.requireNonNull(onCancel, "onCancel is null");
         return lift(s -> new NbpSubscriptionLambdaSubscriber<>(s, onSubscribe, onCancel));
     }
     
@@ -1520,9 +1520,9 @@ public class NbpObservable<T> {
             Function<? super T, ? extends NbpObservable<? extends R>> onNextMapper, 
             Function<? super Throwable, ? extends NbpObservable<? extends R>> onErrorMapper, 
             Supplier<? extends NbpObservable<? extends R>> onCompleteSupplier) {
-        Objects.requireNonNull(onNextMapper);
-        Objects.requireNonNull(onErrorMapper);
-        Objects.requireNonNull(onCompleteSupplier);
+        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
+        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(lift(new NbpOperatorMapNotification<>(onNextMapper, onErrorMapper, onCompleteSupplier)));
     }
 
@@ -1532,9 +1532,9 @@ public class NbpObservable<T> {
             Function<Throwable, ? extends NbpObservable<? extends R>> onErrorMapper, 
             Supplier<? extends NbpObservable<? extends R>> onCompleteSupplier, 
             int maxConcurrency) {
-        Objects.requireNonNull(onNextMapper);
-        Objects.requireNonNull(onErrorMapper);
-        Objects.requireNonNull(onCompleteSupplier);
+        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
+        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(lift(new NbpOperatorMapNotification<>(onNextMapper, onErrorMapper, onCompleteSupplier)), maxConcurrency);
     }
 
@@ -1560,8 +1560,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> NbpObservable<R> flatMap(Function<? super T, ? extends NbpObservable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
-        Objects.requireNonNull(mapper);
-        Objects.requireNonNull(combiner);
+        Objects.requireNonNull(mapper, "mapper is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return flatMap(t -> {
             @SuppressWarnings("unchecked")
             NbpObservable<U> u = (NbpObservable<U>)mapper.apply(t);
@@ -1576,7 +1576,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(mapper, "mapper is null");
         return flatMap(v -> fromIterable(mapper.apply(v)));
     }
 
@@ -1732,7 +1732,7 @@ public class NbpObservable<T> {
     }
 
     public final <R> NbpObservable<R> map(Function<? super T, ? extends R> mapper) {
-        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(mapper, "mapper is null");
         return lift(new NbpOperatorMap<>(mapper));
     }
 
@@ -1743,7 +1743,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> mergeWith(NbpObservable<? extends T> other) {
-        Objects.requireNonNull(other);
+        Objects.requireNonNull(other, "other is null");
         return merge(this, other);
     }
 
@@ -1772,7 +1772,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> NbpObservable<U> ofType(Class<U> clazz) {
-        Objects.requireNonNull(clazz);
+        Objects.requireNonNull(clazz, "clazz is null");
         return filter(clazz::isInstance).cast(clazz);
     }
 
@@ -1884,7 +1884,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> repeatUntil(BooleanSupplier stop) {
-        Objects.requireNonNull(stop);
+        Objects.requireNonNull(stop, "stop is null");
         return create(new NbpOnSubscribeRepeatUntil<>(this, stop));
     }
 
@@ -1943,16 +1943,16 @@ public class NbpObservable<T> {
     
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final <R> NbpObservable<R> replay(Function<? super NbpObservable<T>, ? extends NbpObservable<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(selector);
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(selector, "selector is null");
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.multicastSelector(() -> replay(time, unit, scheduler), selector);
     }
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final <R> NbpObservable<R> replay(final Function<? super NbpObservable<T>, ? extends NbpObservable<R>> selector, final Scheduler scheduler) {
-        Objects.requireNonNull(selector);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(selector, "selector is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.multicastSelector(() -> replay(), 
                 t -> selector.apply(t).observeOn(scheduler));
     }
@@ -1972,8 +1972,8 @@ public class NbpObservable<T> {
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.create(this, time, unit, scheduler, bufferSize);
     }
     
@@ -1989,8 +1989,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final NbpConnectableObservable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return NbpOperatorReplay.create(this, time, unit, scheduler);
     }
 
@@ -2035,7 +2035,7 @@ public class NbpObservable<T> {
     
     @SchedulerSupport(SchedulerKind.NONE)
     public final NbpObservable<T> retryUntil(BooleanSupplier stop) {
-        Objects.requireNonNull(stop);
+        Objects.requireNonNull(stop, "stop is null");
         return retry(Long.MAX_VALUE, e -> !stop.getAsBoolean());
     }
     
@@ -2420,8 +2420,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final NbpObservable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return lift(new NbpOperatorThrottleFirstTimed<T>(skipDuration, unit, scheduler));
     }
 
@@ -2462,8 +2462,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final NbpObservable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return lift(new NbpOperatorTimeInterval<>(unit, scheduler));
     }
 
@@ -2548,8 +2548,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final NbpObservable<Timed<T>> timestamp(TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return map(v -> new Timed<>(v, scheduler.now(unit), unit));
     }
 
@@ -2591,8 +2591,8 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K, V> NbpObservable<Map<K, V>> toMap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
-        Objects.requireNonNull(keySelector);
-        Objects.requireNonNull(valueSelector);
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMap::new, (m, t) -> {
             K key = keySelector.apply(t);
             V value = valueSelector.apply(t);
@@ -2633,10 +2633,10 @@ public class NbpObservable<T> {
             Function<? super T, ? extends V> valueSelector, 
             Supplier<? extends Map<K, Collection<V>>> mapSupplier,
             Function<? super K, ? extends Collection<? super V>> collectionFactory) {
-        Objects.requireNonNull(keySelector);
-        Objects.requireNonNull(valueSelector);
-        Objects.requireNonNull(mapSupplier);
-        Objects.requireNonNull(collectionFactory);
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(valueSelector, "valueSelector is null");
+        Objects.requireNonNull(mapSupplier, "mapSupplier is null");
+        Objects.requireNonNull(collectionFactory, "collectionFactory is null");
         return collect(mapSupplier, (m, t) -> {
             K key = keySelector.apply(t);
 
@@ -2883,7 +2883,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <B> NbpObservable<NbpObservable<T>> window(NbpObservable<B> boundary, int bufferSize) {
-        Objects.requireNonNull(boundary);
+        Objects.requireNonNull(boundary, "boundary is null");
         return lift(new NbpOperatorWindowBoundary<>(boundary, bufferSize));
     }
 
@@ -2898,8 +2898,8 @@ public class NbpObservable<T> {
     public final <U, V> NbpObservable<NbpObservable<T>> window(
             NbpObservable<U> windowOpen, 
             Function<? super U, ? extends NbpObservable<V>> windowClose, int bufferSize) {
-        Objects.requireNonNull(windowOpen);
-        Objects.requireNonNull(windowClose);
+        Objects.requireNonNull(windowOpen, "windowOpen is null");
+        Objects.requireNonNull(windowClose, "windowClose is null");
         return lift(new NbpOperatorWindowBoundarySelector<>(windowOpen, windowClose, bufferSize));
     }
     
@@ -2910,7 +2910,7 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <B> NbpObservable<NbpObservable<T>> window(Supplier<? extends NbpObservable<B>> boundary, int bufferSize) {
-        Objects.requireNonNull(boundary);
+        Objects.requireNonNull(boundary, "boundary is null");
         return lift(new NbpOperatorWindowBoundarySupplier<>(boundary, bufferSize));
     }
 
@@ -2924,14 +2924,14 @@ public class NbpObservable<T> {
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> NbpObservable<R> zipWith(Iterable<? extends U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
-        Objects.requireNonNull(other);
-        Objects.requireNonNull(zipper);
+        Objects.requireNonNull(other, "other is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return create(new NbpOnSubscribeZipIterable<>(this, other, zipper));
     }
 
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> NbpObservable<R> zipWith(NbpObservable<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
-        Objects.requireNonNull(other);
+        Objects.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
 

--- a/src/main/java/io/reactivex/Observable.java
+++ b/src/main/java/io/reactivex/Observable.java
@@ -366,7 +366,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T> Observable<T> defer(Supplier<? extends Publisher<? extends T>> supplier) {
-        Objects.requireNonNull(supplier);
+        Objects.requireNonNull(supplier, "supplier is null");
         return create(new PublisherDefer<>(supplier));
     }
 
@@ -940,7 +940,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public static <T, R> Observable<R> zip(Publisher<? extends Publisher<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
-        Objects.requireNonNull(zipper);
+        Objects.requireNonNull(zipper, "zipper is null");
         return fromPublisher(sources).toList().flatMap(list -> {
             return zipIterable(zipper, false, bufferSize(), list);
         });
@@ -1076,7 +1076,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> ambWith(Publisher<? extends T> other) {
-        Objects.requireNonNull(other);
+        Objects.requireNonNull(other, "other is null");
         return amb(this, other);
     }
 
@@ -1108,7 +1108,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U extends Collection<? super T>> Observable<U> buffer(int count, int skip, Supplier<U> bufferSupplier) {
-        Objects.requireNonNull(bufferSupplier);
+        Objects.requireNonNull(bufferSupplier, "bufferSupplier is null");
         return lift(new OperatorBuffer<>(count, skip, bufferSupplier));
     }
     
@@ -1255,7 +1255,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> Observable<U> cast(Class<U> clazz) {
-        Objects.requireNonNull(clazz);
+        Objects.requireNonNull(clazz, "clazz is null");
         return map(clazz::cast);
     }
 
@@ -1270,7 +1270,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> Observable<U> collectInto(U initialValue, BiConsumer<? super U, ? super T> collector) {
-        Objects.requireNonNull(initialValue);
+        Objects.requireNonNull(initialValue, "initialValue is null");
         return collect(() -> initialValue, collector);
     }
 
@@ -1306,7 +1306,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> Observable<U> concatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper, int prefetch) {
-        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(mapper, "mapper is null");
         return concatMap(v -> new PublisherIterableSource<>(mapper.apply(v)), prefetch);
     }
 
@@ -1421,7 +1421,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> Observable<T> delaySubscription(Supplier<? extends Publisher<U>> delaySupplier) {
-        Objects.requireNonNull(delaySupplier);
+        Objects.requireNonNull(delaySupplier, "delaySupplier is null");
         return fromCallable(delaySupplier::get)  
                 .flatMap(v -> v)  
                 .take(1)  
@@ -1453,8 +1453,8 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K> Observable<T> distinct(Function<? super T, K> keySelector, Supplier<? extends Collection<? super K>> collectionSupplier) {
-        Objects.requireNonNull(keySelector);
-        Objects.requireNonNull(collectionSupplier);
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
         return lift(OperatorDistinct.withCollection(keySelector, collectionSupplier));
     }
 
@@ -1467,7 +1467,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K> Observable<T> distinctUntilChanged(Function<? super T, K> keySelector) {
-        Objects.requireNonNull(keySelector);
+        Objects.requireNonNull(keySelector, "keySelector is null");
         return lift(OperatorDistinct.untilChanged(keySelector));
     }
     
@@ -1496,7 +1496,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> doOnEach(Consumer<? super Try<Optional<T>>> consumer) {
-        Objects.requireNonNull(consumer);
+        Objects.requireNonNull(consumer, "consumer is null");
         return doOnEach(
                 v -> consumer.accept(Try.ofValue(Optional.of(v))),
                 e -> consumer.accept(Try.ofError(e)),
@@ -1508,7 +1508,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> doOnEach(Subscriber<? super T> observer) {
-        Objects.requireNonNull(observer);
+        Objects.requireNonNull(observer, "observer is null");
         return doOnEach(observer::onNext, observer::onError, observer::onComplete, () -> { });
     }
 
@@ -1521,9 +1521,9 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> doOnLifecycle(Consumer<? super Subscription> onSubscribe, LongConsumer onRequest, Runnable onCancel) {
-        Objects.requireNonNull(onSubscribe);
-        Objects.requireNonNull(onRequest);
-        Objects.requireNonNull(onCancel);
+        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
+        Objects.requireNonNull(onRequest, "onRequest is null");
+        Objects.requireNonNull(onCancel, "onCancel is null");
         return lift(s -> new SubscriptionLambdaSubscriber<>(s, onSubscribe, onRequest, onCancel));
     }
 
@@ -1688,9 +1688,9 @@ public class Observable<T> implements Publisher<T> {
             Function<? super T, ? extends Publisher<? extends R>> onNextMapper, 
             Function<? super Throwable, ? extends Publisher<? extends R>> onErrorMapper, 
             Supplier<? extends Publisher<? extends R>> onCompleteSupplier) {
-        Objects.requireNonNull(onNextMapper);
-        Objects.requireNonNull(onErrorMapper);
-        Objects.requireNonNull(onCompleteSupplier);
+        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
+        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(lift(new OperatorMapNotification<>(onNextMapper, onErrorMapper, onCompleteSupplier)));
     }
 
@@ -1701,9 +1701,9 @@ public class Observable<T> implements Publisher<T> {
             Function<Throwable, ? extends Publisher<? extends R>> onErrorMapper, 
             Supplier<? extends Publisher<? extends R>> onCompleteSupplier, 
             int maxConcurrency) {
-        Objects.requireNonNull(onNextMapper);
-        Objects.requireNonNull(onErrorMapper);
-        Objects.requireNonNull(onCompleteSupplier);
+        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
+        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
+        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         return merge(lift(new OperatorMapNotification<>(onNextMapper, onErrorMapper, onCompleteSupplier)), maxConcurrency);
     }
 
@@ -1734,8 +1734,8 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> Observable<R> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayError, int maxConcurrency, int bufferSize) {
-        Objects.requireNonNull(mapper);
-        Objects.requireNonNull(combiner);
+        Objects.requireNonNull(mapper, "mapper is null");
+        Objects.requireNonNull(combiner, "combiner is null");
         return flatMap(t -> {
             Observable<U> u = fromPublisher(mapper.apply(t));
             return u.map(w -> combiner.apply(t, w));
@@ -1751,15 +1751,15 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> Observable<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(mapper, "mapper is null");
         return flatMap(v -> new PublisherIterableSource<>(mapper.apply(v)));
     }
 
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, V> Observable<V> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper, BiFunction<? super T, ? super U, ? extends V> resultSelector) {
-        Objects.requireNonNull(mapper);
-        Objects.requireNonNull(resultSelector);
+        Objects.requireNonNull(mapper, "mapper is null");
+        Objects.requireNonNull(resultSelector, "resultSelector is null");
         return flatMap(t -> new PublisherIterableSource<>(mapper.apply(t)), resultSelector, false, bufferSize(), bufferSize());
     }
 
@@ -1890,7 +1890,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <R> Observable<R> map(Function<? super T, ? extends R> mapper) {
-        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(mapper, "mapper is null");
         return lift(new OperatorMap<>(mapper));
     }
 
@@ -1903,7 +1903,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> mergeWith(Publisher<? extends T> other) {
-        Objects.requireNonNull(other);
+        Objects.requireNonNull(other, "other is null");
         return merge(this, other);
     }
 
@@ -1937,7 +1937,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U> Observable<U> ofType(Class<U> clazz) {
-        Objects.requireNonNull(clazz);
+        Objects.requireNonNull(clazz, "clazz is null");
         return filter(clazz::isInstance).cast(clazz);
     }
 
@@ -1975,7 +1975,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.SPECIAL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> onBackpressureBuffer(int bufferSize, boolean delayError, boolean unbounded, Runnable onOverflow) {
-        Objects.requireNonNull(onOverflow);
+        Objects.requireNonNull(onOverflow, "onOverflow is null");
         return lift(new OperatorOnBackpressureBuffer<>(bufferSize, unbounded, delayError, onOverflow));
     }
 
@@ -1994,7 +1994,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> onBackpressureDrop(Consumer<? super T> onDrop) {
-        Objects.requireNonNull(onDrop);
+        Objects.requireNonNull(onDrop, "onDrop is null");
         return lift(new OperatorOnBackpressureDrop<>(onDrop));
     }
 
@@ -2129,7 +2129,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> repeatUntil(BooleanSupplier stop) {
-        Objects.requireNonNull(stop);
+        Objects.requireNonNull(stop, "stop is null");
         return create(new PublisherRepeatUntil<>(this, stop));
     }
     
@@ -2197,17 +2197,17 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final <R> Observable<R> replay(Function<? super Observable<T>, ? extends Publisher<R>> selector, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(selector);
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(selector, "selector is null");
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return OperatorReplay.multicastSelector(() -> replay(time, unit, scheduler), selector);
     }
     
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final <R> Observable<R> replay(final Function<? super Observable<T>, ? extends Publisher<R>> selector, final Scheduler scheduler) {
-        Objects.requireNonNull(selector);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(selector, "selector is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return OperatorReplay.multicastSelector(() -> replay(), 
                 t -> fromPublisher(selector.apply(t)).observeOn(scheduler));
     }
@@ -2227,8 +2227,8 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final ConnectableObservable<T> replay(final int bufferSize, final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         if (bufferSize < 0) {
             throw new IllegalArgumentException("bufferSize < 0");
         }
@@ -2238,7 +2238,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final ConnectableObservable<T> replay(final int bufferSize, final Scheduler scheduler) {
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return OperatorReplay.observeOn(replay(bufferSize), scheduler);
     }
     
@@ -2251,8 +2251,8 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final ConnectableObservable<T> replay(final long time, final TimeUnit unit, final Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return OperatorReplay.create(this, time, unit, scheduler);
     }
 
@@ -2304,7 +2304,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final Observable<T> retryUntil(BooleanSupplier stop) {
-        Objects.requireNonNull(stop);
+        Objects.requireNonNull(stop, "stop is null");
         return retry(Long.MAX_VALUE, e -> !stop.getAsBoolean());
     }
     
@@ -2779,8 +2779,8 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final Observable<T> throttleFirst(long skipDuration, TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return lift(new OperatorThrottleFirstTimed<T>(skipDuration, unit, scheduler));
     }
 
@@ -2829,8 +2829,8 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final Observable<Timed<T>> timeInterval(TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return lift(new OperatorTimeInterval<>(unit, scheduler));
     }
 
@@ -2926,8 +2926,8 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.PASS_THROUGH)
     @SchedulerSupport(SchedulerKind.CUSTOM)
     public final Observable<Timed<T>> timestamp(TimeUnit unit, Scheduler scheduler) {
-        Objects.requireNonNull(unit);
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return map(v -> new Timed<>(v, scheduler.now(unit), unit));
     }
 
@@ -2978,8 +2978,8 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <K, V> Observable<Map<K, V>> toMap(Function<? super T, ? extends K> keySelector, Function<? super T, ? extends V> valueSelector) {
-        Objects.requireNonNull(keySelector);
-        Objects.requireNonNull(valueSelector);
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(valueSelector, "valueSelector is null");
         return collect(HashMap::new, (m, t) -> {
             K key = keySelector.apply(t);
             V value = valueSelector.apply(t);
@@ -2992,8 +2992,8 @@ public class Observable<T> implements Publisher<T> {
     public final <K, V> Observable<Map<K, V>> toMap(Function<? super T, ? extends K> keySelector, 
             Function<? super T, ? extends V> valueSelector,
             Supplier<? extends Map<K, V>> mapSupplier) {
-        Objects.requireNonNull(keySelector);
-        Objects.requireNonNull(valueSelector);
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(valueSelector, "valueSelector is null");
         return collect(mapSupplier, (m, t) -> {
             K key = keySelector.apply(t);
             V value = valueSelector.apply(t);
@@ -3026,10 +3026,10 @@ public class Observable<T> implements Publisher<T> {
             Function<? super T, ? extends V> valueSelector, 
             Supplier<? extends Map<K, Collection<V>>> mapSupplier,
             Function<? super K, ? extends Collection<? super V>> collectionFactory) {
-        Objects.requireNonNull(keySelector);
-        Objects.requireNonNull(valueSelector);
-        Objects.requireNonNull(mapSupplier);
-        Objects.requireNonNull(collectionFactory);
+        Objects.requireNonNull(keySelector, "keySelector is null");
+        Objects.requireNonNull(valueSelector, "valueSelector is null");
+        Objects.requireNonNull(mapSupplier, "mapSupplier is null");
+        Objects.requireNonNull(collectionFactory, "collectionFactory is null");
         return collect(mapSupplier, (m, t) -> {
             K key = keySelector.apply(t);
 
@@ -3226,7 +3226,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <B> Observable<Observable<T>> window(Publisher<B> boundary, int bufferSize) {
-        Objects.requireNonNull(boundary);
+        Objects.requireNonNull(boundary, "boundary is null");
         return lift(new OperatorWindowBoundary<>(boundary, bufferSize));
     }
 
@@ -3243,8 +3243,8 @@ public class Observable<T> implements Publisher<T> {
     public final <U, V> Observable<Observable<T>> window(
             Publisher<U> windowOpen, 
             Function<? super U, ? extends Publisher<V>> windowClose, int bufferSize) {
-        Objects.requireNonNull(windowOpen);
-        Objects.requireNonNull(windowClose);
+        Objects.requireNonNull(windowOpen, "windowOpen is null");
+        Objects.requireNonNull(windowClose, "windowClose is null");
         return lift(new OperatorWindowBoundarySelector<>(windowOpen, windowClose, bufferSize));
     }
     
@@ -3257,7 +3257,7 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.ERROR)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <B> Observable<Observable<T>> window(Supplier<? extends Publisher<B>> boundary, int bufferSize) {
-        Objects.requireNonNull(boundary);
+        Objects.requireNonNull(boundary, "boundary is null");
         return lift(new OperatorWindowBoundarySupplier<>(boundary, bufferSize));
     }
 
@@ -3273,15 +3273,15 @@ public class Observable<T> implements Publisher<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> Observable<R> zipWith(Iterable<? extends U> other,  BiFunction<? super T, ? super U, ? extends R> zipper) {
-        Objects.requireNonNull(other);
-        Objects.requireNonNull(zipper);
+        Objects.requireNonNull(other, "other is null");
+        Objects.requireNonNull(zipper, "zipper is null");
         return create(new PublisherZipIterable<>(this, other, zipper));
     }
 
     @BackpressureSupport(BackpressureKind.FULL)
     @SchedulerSupport(SchedulerKind.NONE)
     public final <U, R> Observable<R> zipWith(Publisher<? extends U> other, BiFunction<? super T, ? super U, ? extends R> zipper) {
-        Objects.requireNonNull(other);
+        Objects.requireNonNull(other, "other is null");
         return zip(this, other, zipper);
     }
 

--- a/src/main/java/io/reactivex/Single.java
+++ b/src/main/java/io/reactivex/Single.java
@@ -59,7 +59,7 @@ public class Single<T> {
     }
     
     public static <T> Single<T> amb(Iterable<? extends Single<? extends T>> sources) {
-        Objects.requireNonNull(sources);
+        Objects.requireNonNull(sources, "sources is null");
         return create(s -> {
             AtomicBoolean once = new AtomicBoolean();
             CompositeDisposable set = new CompositeDisposable();
@@ -335,7 +335,7 @@ public class Single<T> {
     }
     
     public static <T> Single<T> defer(Supplier<? extends Single<? extends T>> singleSupplier) {
-        Objects.requireNonNull(singleSupplier);
+        Objects.requireNonNull(singleSupplier, "singleSupplier is null");
         return create(s -> {
             Single<? extends T> next;
             
@@ -788,7 +788,7 @@ public class Single<T> {
 
     @SuppressWarnings("unchecked")
     public static <T, R> Single<R> zip(Iterable<? extends Single<? extends T>> sources, Function<? super Object[], ? extends R> zipper) {
-        Objects.requireNonNull(sources);
+        Objects.requireNonNull(sources, "sources is null");
         
         Iterable<? extends Observable<T>> it = () -> {
             Iterator<? extends Single<? extends T>> sit = sources.iterator();
@@ -944,7 +944,7 @@ public class Single<T> {
     }
 
     public final Single<T> ambWith(Single<? extends T> other) {
-        Objects.requireNonNull(other);
+        Objects.requireNonNull(other, "other is null");
         return amb(this, other);
     }
     
@@ -1031,7 +1031,7 @@ public class Single<T> {
     }
     
     public final <U> Single<U> cast(Class<? extends U> clazz) {
-        Objects.requireNonNull(clazz);
+        Objects.requireNonNull(clazz, "clazz is null");
         return create(s -> {
             subscribe(new SingleSubscriber<T>() {
 
@@ -1098,7 +1098,7 @@ public class Single<T> {
     }
     
     public final Single<T> doOnSubscribe(Consumer<? super Disposable> onSubscribe) {
-        Objects.requireNonNull(onSubscribe);
+        Objects.requireNonNull(onSubscribe, "onSubscribe is null");
         return create(s -> {
             subscribe(new SingleSubscriber<T>() {
                 boolean done;
@@ -1139,7 +1139,7 @@ public class Single<T> {
     }
     
     public final Single<T> doOnSuccess(Consumer<? super T> onSuccess) {
-        Objects.requireNonNull(onSuccess);
+        Objects.requireNonNull(onSuccess, "onSuccess is null");
         return create(s -> {
             subscribe(new SingleSubscriber<T>() {
                 @Override
@@ -1168,7 +1168,7 @@ public class Single<T> {
     }
     
     public final Single<T> doOnError(Consumer<? super Throwable> onError) {
-        Objects.requireNonNull(onError);
+        Objects.requireNonNull(onError, "onError is null");
         return create(s -> {
             subscribe(new SingleSubscriber<T>() {
                 @Override
@@ -1196,7 +1196,7 @@ public class Single<T> {
     }
     
     public final Single<T> doOnCancel(Runnable onCancel) {
-        Objects.requireNonNull(onCancel);
+        Objects.requireNonNull(onCancel, "onCancel is null");
         return create(s -> {
             subscribe(new SingleSubscriber<T>() {
                 @Override
@@ -1222,7 +1222,7 @@ public class Single<T> {
     }
 
     public final <R> Single<R> flatMap(Function<? super T, ? extends Single<? extends R>> mapper) {
-        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(mapper, "mapper is null");
         return lift(new SingleOperatorFlatMap<>(mapper));   
     }
 
@@ -1284,8 +1284,8 @@ public class Single<T> {
     }
 
     public final Single<Boolean> contains(Object value, BiPredicate<Object, Object> comparer) {
-        Objects.requireNonNull(value);
-        Objects.requireNonNull(comparer);
+        Objects.requireNonNull(value, "value is null");
+        Objects.requireNonNull(comparer, "comparer is null");
         return create(s -> {
             subscribe(new SingleSubscriber<T>() {
 
@@ -1317,7 +1317,7 @@ public class Single<T> {
     }
     
     public final Single<T> observeOn(Scheduler scheduler) {
-        Objects.requireNonNull(scheduler);
+        Objects.requireNonNull(scheduler, "scheduler is null");
         return create(s -> {
             CompositeDisposable mad = new CompositeDisposable();
             s.onSubscribe(mad);
@@ -1344,7 +1344,7 @@ public class Single<T> {
     }
 
     public final Single<T> onErrorReturn(Supplier<? extends T> valueSupplier) {
-        Objects.requireNonNull(valueSupplier);
+        Objects.requireNonNull(valueSupplier, "valueSupplier is null");
         return create(s -> {
             subscribe(new SingleSubscriber<T>() {
 
@@ -1390,7 +1390,7 @@ public class Single<T> {
     }
 
     public final Single<T> onErrorResumeNext(Function<? super Throwable, ? extends Single<? extends T>> nextFunction) {
-        Objects.requireNonNull(nextFunction);
+        Objects.requireNonNull(nextFunction, "nextFunction is null");
         return create(s -> {
             MultipleAssignmentDisposable mad = new MultipleAssignmentDisposable();
             s.onSubscribe(mad);


### PR DESCRIPTION
That way, users get more information about what was null without having
to look into the sources.
